### PR TITLE
Update Dockerfile to include a geoip filter module

### DIFF
--- a/caddy-cloudflare-ddns-crowdsec/Dockerfile
+++ b/caddy-cloudflare-ddns-crowdsec/Dockerfile
@@ -5,7 +5,8 @@ RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
     --with github.com/WeidiDeng/caddy-cloudflare-ip \
     --with github.com/mholt/caddy-dynamicdns \
-    --with github.com/hslatman/caddy-crowdsec-bouncer/http
+    --with github.com/hslatman/caddy-crowdsec-bouncer/http \
+    --with github.com/porech/caddy-maxmind-geolocation
 
 FROM caddy:2.7.6
 


### PR DESCRIPTION
This module is maintained in the official caddy download page and would allow the ability to filter access to various endpoints in the Caddyfile via the maxmind database.