### PR TITLE
Feat/add netcup duckdns ddns dockerproxy waf defender

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ Coraza is an open source, enterprise-grade, high performance Web Application Fir
 
 It can be used to execute commands on the system based on specific events, such as when a certificate is renewed. This is configured in the `Caddyfile` using the standard [events](https://caddyserver.com/docs/modules/events) directive along with the [events.handlers.exec](https://caddyserver.com/docs/modules/events.handlers.exec) module. Additional information and examples can be found in the [mholt/caddy-events-exec](https://github.com/mholt/caddy-events-exec) repository. Please be mindful of any security implications of the commands you run and how you configure this module.
 
+### Defender
+
+The Caddy Defender plugin is a middleware for Caddy that allows you to block or manipulate requests based on the client's IP address. It is particularly useful for preventing unwanted traffic or polluting AI training data by returning garbage responses. It contains predefined IP ranges for popular AI services (e.g., OpenAI, DeepSeek, GitHub Copilot). More information and usage examples can be found in [mJasonLovesDoggo/caddy-defender](https://github.com/JasonLovesDoggo/caddy-defender) repository.
+
 ## Contributing
 
 Feel free to contribute, request additional Caddy images with your preferred modules, and make things better by opening an [Issue](https://github.com/serfriz/caddy-custom-builds/issues) or [Pull Request](https://github.com/serfriz/caddy-custom-builds/pulls).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you are looking for a specific custom build not available yet in this reposit
 - [**caddy-netcup**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-netcup): includes Netcup DNS module.
 - [**caddy-netcup-ddns**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-netcup): includes Netcup Dynamic DNS module.
 - [**caddy-netcup-ddns-geoip**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-netcup-geoip): includes Netcup Dynamic DNS and GeoIP Filter modules.
+- [**caddy-netcup-duckdns-ddns-dockerproxy-waf-defender**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender): includes Netcup, DuckDNS, Dynamic DNS, Docker Proxy, Coraza WAF and Defender modules.
 - [**caddy-netlify-geoip-security**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-netlify-geoip-security): includes Netlify DNS, GeoIP Filter and Caddy Security modules.
 - [**caddy-ovh-crowdsec-geoip**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-ovh-crowdsec-geoip): includes OVH DNS, CrowdSec Bouncer and GeoIP Filter modules.
 - [**caddy-porkbun-dockerproxy**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-porkbun-dockerproxy): includes Porkbun DNS and Docker Proxy modules.
@@ -68,6 +69,7 @@ If you are looking for a specific custom build not available yet in this reposit
 - [**GeoIP Filter**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#geoip-filter) to allow or block traffic from specific regions based on [Maxmind GeoLite2 database](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) | [porech/caddy-maxmind-geolocation](https://github.com/porech/caddy-maxmind-geolocation)
 - [**Coraza WAF**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#coraza-waf): a Web Application Firewall (WAF) for Caddy | [corazawaf/coraza-caddy](https://github.com/corazawaf/coraza-caddy)
 - [**Events Exec**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#events-exec): implements an event handler that allows to execute commands on the system | [mholt/caddy-events-exec](https://github.com/mholt/caddy-events-exec)
+- [**Defender**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#defender): allows to block or manipulate requests based on the client's IP address | [JasonLovesDoggo/caddy-defender](https://github.com/JasonLovesDoggo/caddy-defender)
 
 ## Usage
 

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -1,47 +1,5 @@
 # syntax=docker/dockerfile:1
-
-# --- Stage 1: Builder Stage ---
-# Use a Go base image to build the Caddy binary and the WAF module
-FROM golang:latest AS builder
-
-# Install essential tools for building: git, wget
-#   - git: required for cloning the repository
-#   - wget: required for downloading files
-#   - &&: combines commands
-#   - no-cache: prevents the apk installer from using the cache (smaller image)
-RUN apk add --no-cache git wget
-
-# Install xcaddy for building custom Caddy binaries with modules.
-#   - @latest will install the latest available version.
-RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-
-# Set the working directory for the build process
-WORKDIR /app
-
-# Clone the caddy-waf repository from GitHub
-RUN git clone https://github.com/fabriziosalmi/caddy-waf.git
-
-# Change to the cloned directory
-WORKDIR /app/caddy-waf
-
-# Fetch and install the necessary Go dependencies, including Caddy and its modules and the caddy-waf plugin.
-#  - go get will fetch and install all required modules
-#  - go.mod will be used to properly build the project.
-RUN go get -v github.com/caddyserver/caddy/v2 github.com/caddyserver/caddy/v2/caddyconfig/caddyfile github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile github.com/caddyserver/caddy/v2 github.com/caddyserver/caddy/v2/modules/caddyhttp github.com/oschwald/maxminddb-golang github.com/fsnotify/fsnotify github.com/fabriziosalmi/caddy-waf
-
-# Clean up and update the go.mod file
-# - go mod tidy will tidy up go.mod file, removing unused dependencies
-RUN go mod tidy
-
-# Download the GeoLite2 Country database from a known location.
-# - Use a reliable download location for this file.
-RUN wget https://git.io/GeoLite2-Country.mmdb -O GeoLite2-Country.mmdb
-
-# Clean up previous build artifacts, to ensure a clean build
-RUN rm -rf buildenv_*
-
-# Build the Caddy binary using xcaddy with the caddy-waf module.
-#   - This creates the custom caddy binary with the waf
+FROM caddy:2.9.1-builder AS builder
 
 RUN xcaddy build \
     --with github.com/caddy-dns/netcup \
@@ -49,22 +7,8 @@ RUN xcaddy build \
     --with github.com/caddy-dns/duckdns \
     --with github.com/mholt/caddy-dynamicdns \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
-    --with github.com/fabriziosalmi/caddy-waf=./ \
     --with github.com/jasonlovesdoggo/caddy-defender
-
 
 FROM caddy:2.9.1
 
-# Set the working directory for the running container.
-WORKDIR /app
-
-# Copy the Caddy binary from the builder stage.
-#  - This copies the executable from the builder stage
-COPY --from=builder /app/caddy-waf/caddy /usr/bin/caddy
-
-# Copy the GeoLite2 database, rules, blacklists, and Caddyfile from the builder stage.
-#  - This copies the files into the /app directory in the final image.
-COPY --from=builder /app/caddy-waf/GeoLite2-Country.mmdb /app/
-COPY --from=builder /app/caddy-waf/rules.json /app/
-COPY --from=builder /app/caddy-waf/ip_blacklist.txt /app/
-COPY --from=builder /app/caddy-waf/dns_blacklist.txt /app/
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM caddy:2.8.4-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/netcup \
+    --replace github.com/libdns/netcup=github.com/Monviech/libdns-netcup@libdns-patch \
+    --with github.com/caddy-dns/duckdns \
+    --with github.com/mholt/caddy-dynamicdns \
+    --with github.com/mholt/caddy-ratelimit \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2
+
+FROM caddy:2.8.4
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -1,14 +1,15 @@
 # syntax=docker/dockerfile:1
-FROM caddy:2.8.4-builder AS builder
+FROM caddy:2.9.1-builder AS builder
 
 RUN xcaddy build \
     --with github.com/caddy-dns/netcup \
     --replace github.com/libdns/netcup=github.com/Monviech/libdns-netcup@libdns-patch \
     --with github.com/caddy-dns/duckdns \
     --with github.com/mholt/caddy-dynamicdns \
-    --with github.com/mholt/caddy-ratelimit \
-    --with github.com/lucaslorentz/caddy-docker-proxy/v2
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
+    --with github.com/fabriziosalmi/caddy-waf \
+    --with github.com/jasonlovesdoggo/caddy-defender
 
-FROM caddy:2.8.4
+FROM caddy:2.9.1
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -2,7 +2,7 @@
 
 # --- Stage 1: Builder Stage ---
 # Use a Go base image to build the Caddy binary and the WAF module
-FROM golang:1.22.3-alpine AS builder
+FROM golang:latest AS builder
 
 # Install essential tools for building: git, wget
 #   - git: required for cloning the repository

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -1,5 +1,47 @@
 # syntax=docker/dockerfile:1
-FROM caddy:2.9.1-builder AS builder
+
+# --- Stage 1: Builder Stage ---
+# Use a Go base image to build the Caddy binary and the WAF module
+FROM golang:1.22.3-alpine AS builder
+
+# Install essential tools for building: git, wget
+#   - git: required for cloning the repository
+#   - wget: required for downloading files
+#   - &&: combines commands
+#   - no-cache: prevents the apk installer from using the cache (smaller image)
+RUN apk add --no-cache git wget
+
+# Install xcaddy for building custom Caddy binaries with modules.
+#   - @latest will install the latest available version.
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+# Set the working directory for the build process
+WORKDIR /app
+
+# Clone the caddy-waf repository from GitHub
+RUN git clone https://github.com/fabriziosalmi/caddy-waf.git
+
+# Change to the cloned directory
+WORKDIR /app/caddy-waf
+
+# Fetch and install the necessary Go dependencies, including Caddy and its modules and the caddy-waf plugin.
+#  - go get will fetch and install all required modules
+#  - go.mod will be used to properly build the project.
+RUN go get -v github.com/caddyserver/caddy/v2 github.com/caddyserver/caddy/v2/caddyconfig/caddyfile github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile github.com/caddyserver/caddy/v2 github.com/caddyserver/caddy/v2/modules/caddyhttp github.com/oschwald/maxminddb-golang github.com/fsnotify/fsnotify github.com/fabriziosalmi/caddy-waf
+
+# Clean up and update the go.mod file
+# - go mod tidy will tidy up go.mod file, removing unused dependencies
+RUN go mod tidy
+
+# Download the GeoLite2 Country database from a known location.
+# - Use a reliable download location for this file.
+RUN wget https://git.io/GeoLite2-Country.mmdb -O GeoLite2-Country.mmdb
+
+# Clean up previous build artifacts, to ensure a clean build
+RUN rm -rf buildenv_*
+
+# Build the Caddy binary using xcaddy with the caddy-waf module.
+#   - This creates the custom caddy binary with the waf
 
 RUN xcaddy build \
     --with github.com/caddy-dns/netcup \
@@ -7,9 +49,22 @@ RUN xcaddy build \
     --with github.com/caddy-dns/duckdns \
     --with github.com/mholt/caddy-dynamicdns \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
-    --with github.com/fabriziosalmi/caddy-waf \
+    --with github.com/fabriziosalmi/caddy-waf=./ \
     --with github.com/jasonlovesdoggo/caddy-defender
+
 
 FROM caddy:2.9.1
 
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+# Set the working directory for the running container.
+WORKDIR /app
+
+# Copy the Caddy binary from the builder stage.
+#  - This copies the executable from the builder stage
+COPY --from=builder /app/caddy-waf/caddy /usr/bin/caddy
+
+# Copy the GeoLite2 database, rules, blacklists, and Caddyfile from the builder stage.
+#  - This copies the files into the /app directory in the final image.
+COPY --from=builder /app/caddy-waf/GeoLite2-Country.mmdb /app/
+COPY --from=builder /app/caddy-waf/rules.json /app/
+COPY --from=builder /app/caddy-waf/ip_blacklist.txt /app/
+COPY --from=builder /app/caddy-waf/dns_blacklist.txt /app/

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/Dockerfile
@@ -7,8 +7,12 @@ RUN xcaddy build \
     --with github.com/caddy-dns/duckdns \
     --with github.com/mholt/caddy-dynamicdns \
     --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
+    --with github.com/corazawaf/coraza-caddy/v2 \
     --with github.com/jasonlovesdoggo/caddy-defender
 
 FROM caddy:2.9.1
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# Docker Proxy not enabled by default
+# CMD ["caddy", "docker-proxy"]

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
@@ -1,0 +1,37 @@
+# Caddy Docker build with Netcup, DuckDNS, Dynamic DNS, Rate Limit and Docker Proxy modules
+
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub%20-%20mwitasse%2Fcaddy--netcup--duckdns--ddns--ratelimit--dockerproxy%20-%20%230db7ed?style=flat&logo=docker)](https://hub.docker.com/r/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy)
+[![GitHub](https://img.shields.io/badge/GitHub%20-%20mwitasse%2Fcaddy--netcup--duckdns--ddns--ratelimit--dockerproxy%20-%20%23333?style=flat&logo=github)](https://ghcr.io/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy)
+
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/mwitasse/caddy-custom-builds?label=Release)](https://github.com/mwitasse/caddy-custom-builds/releases)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/mwitasse/caddy-custom-builds/build.caddy-netcup-duckdns-ddns-ratelimit-dockerproxy.yml?label=Build)](https://github.com/mwitasse/caddy-custom-builds/actions/workflows/build.caddy-netcup-duckdns-ddns-ratelimit-dockerproxy.yml)
+
+This image is updated automatically by GitHub Actions when a new version of [Caddy](https://github.com/caddyserver/caddy) is released using the official [Caddy Docker](https://hub.docker.com/_/caddy) image and the following modules:
+- [**Netcup DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for Netcup DNS-01 ACME validation support | [caddy-dns/netcup](https://github.com/caddy-dns/netcup-ddns)
+- [**DuckDNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for DuckDNS DNS-01 ACME validation support | [caddy-dns/duckdns](https://github.com/caddy-dns/duckdns)
+- [**Dynamic DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dynamic-dns): updates the DNS records with the public IP address of your instance | [mholt/caddy-dynamicdns](https://caddyserver.com/docs/modules/dynamic_dns)
+- [**Rate Limit**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#rate-limit): implements both internal and distributed HTTP rate limiting | [mholt/caddy-ratelimit](https://github.com/mholt/caddy-ratelimit)
+- [**Docker Proxy**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#docker-proxy): enables Caddy to be used for Docker containers via labels | [lucaslorentz/caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy)
+
+## Usage
+
+Since this image built off the official Caddy Docker image, the same [volumes](https://docs.docker.com/storage/volumes/) and/or [bind mounts](https://docs.docker.com/storage/bind-mounts/), ports mapping, etc. can be used with this container. Additional [environment variables](https://caddyserver.com/docs/caddyfile/concepts#environment-variables) may be needed for the added modules. Please, refer to the repository's [README](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#container-creation) file for further usage instructions.
+
+Docker builds for all Caddy supported platforms available at the following container registries:
+- [**Docker Hub**](https://hub.docker.com/r/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy) `docker pull mwitasse/netcup-duckdns-ddns-ratelimit-dockerproxy:latest`
+- [**GitHub Packages**](https://ghcr.io/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy) `docker pull ghcr.io/mwitasse/netcup-duckdns-ddns-ratelimit-dockerproxy:latest`
+
+### Tags
+
+The following tags are available for the `mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy` image:
+
+- `latest`
+- `<version>` (eg: `2.7.4`, including: `2.7`, `2`, etc.)
+
+## Contributing
+
+Feel free to contribute, request additional Caddy images with your preferred modules, and make things better by opening an [Issue](https://github.com/mwitasse/caddy-custom-builds/issues) or [Pull Request](https://github.com/mwitasse/caddy-custom-builds/pulls).
+
+## License
+
+Software under [GPL-3.0](https://github.com/mwitasse/caddy-custom-builds/blob/main/LICENSE) ensures users' freedom to use, modify, and distribute it while keeping the source code accessible. It promotes transparency, collaboration, and knowledge sharing. Users agree to comply with the GPL-3.0 license terms and provide the same freedom to others.

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
@@ -1,4 +1,4 @@
-# Caddy Docker build with Netcup, DuckDNS, Dynamic DNS, Docker Proxy and Defender modules
+# Caddy Docker build with Netcup, DuckDNS, Dynamic DNS, Docker Proxy, Coraza WAF and Defender modules
 
 [![Docker Hub](https://img.shields.io/badge/Docker%20Hub%20-%20serfriz%2Fcaddy--netcup--duckdns--ddns--dockerproxy--waf--defender%20-%20%230db7ed?style=flat&logo=docker)](https://hub.docker.com/r/serfriz/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender)
 [![GitHub](https://img.shields.io/badge/GitHub%20-%20serfriz%2Fcaddy--netcup--duckdns--ddns--dockerproxy--waf--defender%20-%20%23333?style=flat&logo=github)](https://ghcr.io/serfriz/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender)

--- a/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
+++ b/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender/README.md
@@ -1,37 +1,40 @@
-# Caddy Docker build with Netcup, DuckDNS, Dynamic DNS, Rate Limit and Docker Proxy modules
+# Caddy Docker build with Netcup, DuckDNS, Dynamic DNS, Docker Proxy and Defender modules
 
-[![Docker Hub](https://img.shields.io/badge/Docker%20Hub%20-%20mwitasse%2Fcaddy--netcup--duckdns--ddns--ratelimit--dockerproxy%20-%20%230db7ed?style=flat&logo=docker)](https://hub.docker.com/r/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy)
-[![GitHub](https://img.shields.io/badge/GitHub%20-%20mwitasse%2Fcaddy--netcup--duckdns--ddns--ratelimit--dockerproxy%20-%20%23333?style=flat&logo=github)](https://ghcr.io/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy)
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub%20-%20serfriz%2Fcaddy--netcup--duckdns--ddns--dockerproxy--waf--defender%20-%20%230db7ed?style=flat&logo=docker)](https://hub.docker.com/r/serfriz/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender)
+[![GitHub](https://img.shields.io/badge/GitHub%20-%20serfriz%2Fcaddy--netcup--duckdns--ddns--dockerproxy--waf--defender%20-%20%23333?style=flat&logo=github)](https://ghcr.io/serfriz/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender)
+[![Quay](https://img.shields.io/badge/Quay%20-%20serfriz%2Fcaddy--netcup--duckdns--ddns--dockerproxy--waf--defender%20-%20%23CC0000?style=flat&logo=redhat)](https://quay.io/serfriz/caddy-netcup-duckdns-ddns-dockerproxy-waf-defender)
 
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/mwitasse/caddy-custom-builds?label=Release)](https://github.com/mwitasse/caddy-custom-builds/releases)
-[![GitHub build status](https://img.shields.io/github/actions/workflow/status/mwitasse/caddy-custom-builds/build.caddy-netcup-duckdns-ddns-ratelimit-dockerproxy.yml?label=Build)](https://github.com/mwitasse/caddy-custom-builds/actions/workflows/build.caddy-netcup-duckdns-ddns-ratelimit-dockerproxy.yml)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/serfriz/caddy-custom-builds?label=Release)](https://github.com/serfriz/caddy-custom-builds/releases)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/serfriz/caddy-custom-builds/build.caddy-netcup-duckdns-ddns-dockerproxy-waf-defender.yml?label=Build)](https://github.com/serfriz/caddy-custom-builds/actions/workflows/build.caddy-netcup-duckdns-ddns-dockerproxy-waf-defender.yml)
 
 This image is updated automatically by GitHub Actions when a new version of [Caddy](https://github.com/caddyserver/caddy) is released using the official [Caddy Docker](https://hub.docker.com/_/caddy) image and the following modules:
 - [**Netcup DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for Netcup DNS-01 ACME validation support | [caddy-dns/netcup](https://github.com/caddy-dns/netcup-ddns)
 - [**DuckDNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for DuckDNS DNS-01 ACME validation support | [caddy-dns/duckdns](https://github.com/caddy-dns/duckdns)
 - [**Dynamic DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dynamic-dns): updates the DNS records with the public IP address of your instance | [mholt/caddy-dynamicdns](https://caddyserver.com/docs/modules/dynamic_dns)
-- [**Rate Limit**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#rate-limit): implements both internal and distributed HTTP rate limiting | [mholt/caddy-ratelimit](https://github.com/mholt/caddy-ratelimit)
 - [**Docker Proxy**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#docker-proxy): enables Caddy to be used for Docker containers via labels | [lucaslorentz/caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy)
+- [**Coraza WAF**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#coraza-waf): a Web Application Firewall (WAF) for Caddy | [corazawaf/coraza-caddy](https://github.com/corazawaf/coraza-caddy)
+- [**Defender**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#defender): allows to block or manipulate requests based on the client's IP address | [JasonLovesDoggo/caddy-defender](https://github.com/JasonLovesDoggo/caddy-defender)
 
 ## Usage
 
 Since this image built off the official Caddy Docker image, the same [volumes](https://docs.docker.com/storage/volumes/) and/or [bind mounts](https://docs.docker.com/storage/bind-mounts/), ports mapping, etc. can be used with this container. Additional [environment variables](https://caddyserver.com/docs/caddyfile/concepts#environment-variables) may be needed for the added modules. Please, refer to the repository's [README](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#container-creation) file for further usage instructions.
 
 Docker builds for all Caddy supported platforms available at the following container registries:
-- [**Docker Hub**](https://hub.docker.com/r/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy) `docker pull mwitasse/netcup-duckdns-ddns-ratelimit-dockerproxy:latest`
-- [**GitHub Packages**](https://ghcr.io/mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy) `docker pull ghcr.io/mwitasse/netcup-duckdns-ddns-ratelimit-dockerproxy:latest`
+- [**Docker Hub**](https://hub.docker.com/r/serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy) `docker pull serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy:latest`
+- [**GitHub Packages**](https://ghcr.io/serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy) `docker pull ghcr.io/serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy:latest`
+- [**Quay**](https://quay.io/serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy) `docker pull quay.io/serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy:latest`
 
 ### Tags
 
-The following tags are available for the `mwitasse/caddy-netcup-duckdns-ddns-ratelimit-dockerproxy` image:
+The following tags are available for the `serfriz/caddy-cloudflare-ddns-crowdsec-geoip-security-dockerproxy` image:
 
 - `latest`
 - `<version>` (eg: `2.7.4`, including: `2.7`, `2`, etc.)
 
 ## Contributing
 
-Feel free to contribute, request additional Caddy images with your preferred modules, and make things better by opening an [Issue](https://github.com/mwitasse/caddy-custom-builds/issues) or [Pull Request](https://github.com/mwitasse/caddy-custom-builds/pulls).
+Feel free to contribute, request additional Caddy images with your preferred modules, and make things better by opening an [Issue](https://github.com/serfriz/caddy-custom-builds/issues) or [Pull Request](https://github.com/serfriz/caddy-custom-builds/pulls).
 
 ## License
 
-Software under [GPL-3.0](https://github.com/mwitasse/caddy-custom-builds/blob/main/LICENSE) ensures users' freedom to use, modify, and distribute it while keeping the source code accessible. It promotes transparency, collaboration, and knowledge sharing. Users agree to comply with the GPL-3.0 license terms and provide the same freedom to others.
+Software under [GPL-3.0](https://github.com/serfriz/caddy-custom-builds/blob/main/LICENSE) ensures users' freedom to use, modify, and distribute it while keeping the source code accessible. It promotes transparency, collaboration, and knowledge sharing. Users agree to comply with the GPL-3.0 license terms and provide the same freedom to others.


### PR DESCRIPTION
Added build with build with Netcup, DuckDNS, Dynamic DNS, Docker Proxy, Coraza WAF and Defender modules.
Docker Proxy is not enabled by default, though, which can be overridden when running the container.