### PR TITLE
Add Caddy build with TransIP DNS module

### DIFF
--- a/.github/workflows/build.caddy-transip.yml
+++ b/.github/workflows/build.caddy-transip.yml
@@ -1,0 +1,107 @@
+# Workflow to build and push a Docker image to Docker Hub, GitHub and Quay Container Registries
+name: Build caddy-transip
+
+# Controls when the action will run
+on:
+  workflow_dispatch:  # allows to run the workflow manually from the Actions tab
+  schedule:
+    - cron: '0 0 1 * *'  # runs at 00:00 on the first day of every month
+  push:
+    branches: main
+    paths:
+      - caddy-transip/Dockerfile
+
+# Environment variables available to all jobs and steps in this workflow
+env:
+  DOCKER_BUILDKIT: 1
+  DOCKER_NAME: caddy-transip
+  DOCKER_DESCRIPTION: "Caddy Docker custom build with TransIP DNS module"
+
+# Jobs to run once the workflow is triggered
+jobs:
+  # Job to get image and repository details
+  metadata:
+    name: Get image and repository details
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      labels: ${{ steps.metadata.outputs.labels }}
+      tags: ${{ steps.metadata.outputs.tags }}
+      platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Parse Caddy version
+        id: version
+        run: echo "version=$(grep -Eo 'caddy:[0-9]+\.[0-9]+\.[0-9]+$' $DOCKER_NAME/Dockerfile | cut -d ':' -f2)" | tee -a $GITHUB_OUTPUT
+
+      - name: Generate image metadata with Caddy version
+        uses: docker/metadata-action@v5
+        id: metadata
+        with:
+          images: |
+            docker.io/${{ github.actor }}/${{ env.DOCKER_NAME }}
+            ghcr.io/${{ github.actor }}/${{ env.DOCKER_NAME }}
+            quay.io/${{ github.actor }}/${{ env.DOCKER_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=v${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}},value=v${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.title=${{ env.DOCKER_NAME }}
+            org.opencontainers.image.description=${{ env.DOCKER_DESCRIPTION }}
+
+  # Job to build and publish Docker image
+  build:
+    name: Build and publish Docker image
+    runs-on: ubuntu-latest
+    needs: metadata
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Repository
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Quay Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and publish container image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: .
+          file: ./${{ env.DOCKER_NAME }}/Dockerfile
+          push: true
+          provenance: false
+          tags: ${{ needs.metadata.outputs.tags }}
+          labels: ${{ needs.metadata.outputs.labels }}
+          platforms: ${{ needs.metadata.outputs.platforms }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you are looking for a specific custom build not available yet in this reposit
 - [**caddy-ovh-crowdsec-geoip**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-ovh-crowdsec-geoip): includes OVH DNS, CrowdSec Bouncer and GeoIP Filter modules.
 - [**caddy-porkbun-dockerproxy**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-porkbun-dockerproxy): includes Porkbun DNS and Docker Proxy modules.
 - [**caddy-ratelimit-dockerproxy-sablier**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-ratelimit-dockerproxy-sablier): includes Rate Limit, Docker Proxy and Sablier modules.
+- [**caddy-transip**](https://github.com/serfriz/caddy-custom-builds/tree/main/caddy-transip): includes TransIP DNS module.
 
 ### Modules:
 
@@ -59,6 +60,7 @@ If you are looking for a specific custom build not available yet in this reposit
 - [**Netlify DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for Netlify DNS-01 ACME validation support | [caddy-dns/netlify](https://github.com/caddy-dns/netlify)
 - [**OVH DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for OVH DNS-01 ACME validation support | [caddy-dns/ovh](https://github.com/caddy-dns/ovh)
 - [**Porkbun DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for Porkbun DNS-01 ACME validation support | [caddy-dns/porkbun](https://github.com/caddy-dns/porkbun)
+- [**TransIP DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for TransIP DNS-01 ACME validation support | [caddy-dns/transip](https://github.com/caddy-dns/transip)
 - [**Dynamic DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dynamic-dns): updates the DNS records with the public IP address of your instance | [mholt/caddy-dynamicdns](https://github.com/mholt/caddy-dynamicdns)
 - [**CrowdSec Bouncer**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#crowdsec-bouncer): blocks malicious traffic based on [CrowdSec](https://www.crowdsec.net/) decisions | [hslatman/caddy-crowdsec-bouncer](https://github.com/hslatman/caddy-crowdsec-bouncer)
 - [**Rate Limit**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#rate-limit): implements both internal and distributed HTTP rate limiting | [mholt/caddy-ratelimit](https://github.com/mholt/caddy-ratelimit)

--- a/caddy-transip/Dockerfile
+++ b/caddy-transip/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM caddy:2.10.2-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/transip
+
+FROM caddy:2.10.2
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy-transip/README.md
+++ b/caddy-transip/README.md
@@ -1,0 +1,35 @@
+# Caddy Docker build with TransIP DNS module
+
+[![Docker Hub](https://img.shields.io/badge/Docker%20Hub%20-%20serfriz%2Fcaddy--transip%20-%20%230db7ed?style=flat&logo=docker)](https://hub.docker.com/r/serfriz/caddy-transip)
+[![GitHub](https://img.shields.io/badge/GitHub%20-%20serfriz%2Fcaddy--transip%20-%20%23333?style=flat&logo=github)](https://ghcr.io/serfriz/caddy-transip)
+[![Quay](https://img.shields.io/badge/Quay%20-%20serfriz%2Fcaddy--transip%20-%20%23CC0000?style=flat&logo=redhat)](https://quay.io/serfriz/caddy-transip)
+
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/serfriz/caddy-custom-builds?label=Release)](https://github.com/serfriz/caddy-custom-builds/releases)
+[![GitHub build status](https://img.shields.io/github/actions/workflow/status/serfriz/caddy-custom-builds/build.caddy-transip.yml?label=Build)](https://github.com/serfriz/caddy-custom-builds/actions/workflows/build.caddy-transip.yml)
+
+This image is updated automatically by GitHub Actions when a new version of [Caddy](https://github.com/caddyserver/caddy) is released using the official [Caddy Docker](https://hub.docker.com/_/caddy) image and the following module:
+- [**TransIP DNS**](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#dns-modules): for TransIP DNS-01 ACME validation support | [caddy-dns/transip](https://github.com/caddy-dns/transip)
+
+## Usage
+
+Since this image built off the official Caddy Docker image, the same [volumes](https://docs.docker.com/storage/volumes/) and/or [bind mounts](https://docs.docker.com/storage/bind-mounts/), ports mapping, etc. can be used with this container. Additional [environment variables](https://caddyserver.com/docs/caddyfile/concepts#environment-variables) may be needed for the added module. Please, refer to the repository's [README](https://github.com/serfriz/caddy-custom-builds?tab=readme-ov-file#container-creation) file for further usage instructions.
+
+Docker builds for all Caddy supported platforms available at the following container registries:
+- [**Docker Hub**](https://hub.docker.com/r/serfriz/caddy-transip) `docker pull serfriz/caddy-transip:latest`
+- [**GitHub Packages**](https://ghcr.io/serfriz/caddy-transip) `docker pull ghcr.io/serfriz/caddy-transip:latest`
+- [**Quay**](https://quay.io/serfriz/caddy-transip) `docker pull quay.io/serfriz/caddy-transip:latest`
+
+### Tags
+
+The following tags are available for the `serfriz/caddy-transip` image:
+
+- `latest`
+- `<version>` (eg: `2.7.4`, including: `2.7`, `2`, etc.)
+
+## Contributing
+
+Feel free to contribute, request additional Caddy images with your preferred modules, and make things better by opening an [Issue](https://github.com/serfriz/caddy-custom-builds/issues) or [Pull Request](https://github.com/serfriz/caddy-custom-builds/pulls).
+
+## License
+
+Software under [GPL-3.0](https://github.com/serfriz/caddy-custom-builds/blob/main/LICENSE) ensures users' freedom to use, modify, and distribute it while keeping the source code accessible. It promotes transparency, collaboration, and knowledge sharing. Users agree to comply with the GPL-3.0 license terms and provide the same freedom to others.


### PR DESCRIPTION
Add new caddy-transip build for TransIP DNS-01 ACME validation support.

Changes:

    Add caddy-transip/Dockerfile with TransIP DNS module
    Add caddy-transip/README.md with build documentation
    Add GitHub Actions workflow for automated builds
    Update main README.md with build and module entries